### PR TITLE
clean up base

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @yedhink 


### PR DESCRIPTION
Fixes #1 
@yedhink  Please review.
Removes .github/CODEOWNERS